### PR TITLE
Make error impls public

### DIFF
--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -11,13 +11,15 @@ use serde::ser;
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing JSON data.
 pub struct Error {
-    err: Box<ErrorImpl>,
+#[doc(hidden)]
+    pub err: Box<ErrorImpl>,
 }
 
 /// Alias for a `Result` with the error type `serde_json::Error`.
 pub type Result<T> = result::Result<T, Error>;
 
-enum ErrorImpl {
+#[doc(hidden)]
+pub enum ErrorImpl {
     /// The JSON value had some syntatic error.
     Syntax(ErrorCode, usize, usize),
 

--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -11,15 +11,13 @@ use serde::ser;
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing JSON data.
 pub struct Error {
-#[doc(hidden)]
-    pub err: Box<ErrorImpl>,
+    err: Box<ErrorImpl>,
 }
 
 /// Alias for a `Result` with the error type `serde_json::Error`.
 pub type Result<T> = result::Result<T, Error>;
 
-#[doc(hidden)]
-pub enum ErrorImpl {
+enum ErrorImpl {
     /// The JSON value had some syntatic error.
     Syntax(ErrorCode, usize, usize),
 
@@ -107,6 +105,15 @@ impl Error {
             f(code)
         } else {
             self
+        }
+    }
+
+    /// Extract the syntax error, if present
+    pub fn syntax_error(&self) -> Option<(ErrorCode, usize, usize)> {
+        let error_impl = self.err.as_ref();
+        match error_impl {
+            &ErrorImpl::Syntax(ref ec, line, col) => Some((ec.clone(), line, col)),
+            _ => None
         }
     }
 }


### PR DESCRIPTION
A change from 0.8 to 0.9 moved errors behind an opaque type that only allows us to display the error string. This behavior prevents us from inspecting the error's cause + line/col #s, which prevents us from handling error programmatically. So this PR simply makes the internals of the error public for us to manipulate again- the real solution would be adding an interface to the errors to that properly reveals this information again.